### PR TITLE
Add Product repository layer  

### DIFF
--- a/beststore/src/main/java/com/macodinglab/beststore/controller/ProductController.java
+++ b/beststore/src/main/java/com/macodinglab/beststore/controller/ProductController.java
@@ -1,0 +1,31 @@
+package com.macodinglab.beststore.controller;
+
+
+import com.macodinglab.beststore.models.Product;
+import com.macodinglab.beststore.repository.ProductsRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/products")
+public class ProductController {
+    @Autowired
+    private ProductsRepository repository;
+
+    @GetMapping({"","/"})
+    public String showProductList(Model model) {
+        List<Product> products = repository.findAll();
+        model.addAttribute("products",products);
+        return "products/index";
+    }
+
+
+
+
+
+}

--- a/beststore/src/main/java/com/macodinglab/beststore/repository/ProductsRepository.java
+++ b/beststore/src/main/java/com/macodinglab/beststore/repository/ProductsRepository.java
@@ -1,0 +1,7 @@
+package com.macodinglab.beststore.repository;
+
+import com.macodinglab.beststore.models.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductsRepository extends JpaRepository<Product, Integer> {
+}

--- a/beststore/src/main/resources/templates/products/index.html
+++ b/beststore/src/main/resources/templates/products/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>


### PR DESCRIPTION
### **Pull Request Title**  
📦 [Feature] Add Product repository layer  

### **Branch**  
`ft-create-repository` → `main` (or `develop`)  

### **Overview**  
This PR introduces the **data access layer** for the `Product` entity using Spring Data JPA.  

### **Key Changes**  

#### 1. Repository Interface (`ProductsRepository.java`)  
```java
public interface ProductsRepository extends JpaRepository<Product, Integer> {
    // Inherits CRUD operations:
    // findAll(), findById(), save(), deleteById(), etc.
}
```

#### 2. Integration with Existing Components  
- Connected to `Product` entity (JPA annotations already defined)  
- Injected into `ProductController` for data access  

### **Why This Matters**  
✅ **Standardized data access**:  
   - Leverages Spring Data JPA’s built-in methods  
   - Eliminates boilerplate SQL queries  
   -    -    - 
### **Testing Instructions**  
1. Verify repository works with:  
   ```java
   // Smoke test in a @SpringBootTest
   assertThat(repository.findAll()).isNotEmpty(); 
   ```
2. Confirm `ProductController` successfully fetches data via:  
   ```bash
   curl http://localhost:8080/products
   ```